### PR TITLE
Add implicit `Content-Length` if `content` is given in a `HttpResponse`

### DIFF
--- a/src/main/java/io/kerosenelabs/kindling/HttpResponse.java
+++ b/src/main/java/io/kerosenelabs/kindling/HttpResponse.java
@@ -13,6 +13,11 @@ public class HttpResponse {
         this.httpStatus = builder.httpStatus;
         this.headers = builder.headers;
         this.content = builder.content;
+
+        // implicitly calculate Content-Length
+        if (content != null) {
+            headers.put("Content-Length", Integer.toString(content.getBytes().length));
+        }
     }
 
     public String toString() {

--- a/src/main/java/io/kerosenelabs/kindling/constant/HttpStatus.java
+++ b/src/main/java/io/kerosenelabs/kindling/constant/HttpStatus.java
@@ -3,7 +3,7 @@ package io.kerosenelabs.kindling.constant;
 public enum HttpStatus {
     OK(200, "OK"),
     CREATED(201, "Created"),
-    NO_RESPONSE(204, "No Response"),
+    NO_CONTENT(204, "No Content"),
     BAD_REQUEST(400, "Bad Request"),
     NOT_FOUND(404, "Not Found"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error");


### PR DESCRIPTION
Closes #1 